### PR TITLE
Clone from "https://github" instead of git@github

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -113,7 +113,7 @@ Where can I get the source for hangwatch?::
 You can use `git` to clone the hangwatch repo on github:
 +
 ----
-git clone git@github.com:jumanjiman/hangwatch.git
+git clone https://github.com/jumanjiman/hangwatch.git
 ----
 +
 You can also download one version of the source from 


### PR DESCRIPTION
The format "git clone git@github.com:jumanjiman/hangwatch.git" currently gives me errors such as "Permission denied (publickey)". The format "git clone https://github.com/jumanjiman/hangwatch.git" worked for me once I set up ssh keys per GitHub instructions. A quick 'net search indicated that the https format is currently preferred in the general case.
